### PR TITLE
Disable AP mode after we're configured and connected to WiFi

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -148,10 +148,11 @@ static void websocket_event_handler(void *handler_args, esp_event_base_t base,
 
 // Whenever we fall back into AP+STA, redraw the config page:
 static void show_config_screen(void) {
-    // Render the “TRONBYT-CONFIG” WebP asset
-    gfx_update(ASSET_CONFIG_WEBP, ASSET_CONFIG_WEBP_LEN);
-    // Force an immediate repaint
-    isAnimating = -1;
+  ESP_LOGI(TAG, "Loading Config WEBP");
+  // Render the “TRONBYT-CONFIG” WebP asset
+  gfx_update(ASSET_CONFIG_WEBP, ASSET_CONFIG_WEBP_LEN);
+  // Force an immediate repaint
+  isAnimating = -1;
 }
 
 void app_main(void) {

--- a/src/main.c
+++ b/src/main.c
@@ -146,6 +146,14 @@ static void websocket_event_handler(void *handler_args, esp_event_base_t base,
   }
 }
 
+// Whenever we fall back into AP+STA, redraw the config page:
+static void show_config_screen(void) {
+    // Render the “TRONBYT-CONFIG” WebP asset
+    gfx_update(ASSET_CONFIG_WEBP, ASSET_CONFIG_WEBP_LEN);
+    // Force an immediate repaint
+    isAnimating = -1;
+}
+
 void app_main(void) {
   ESP_LOGI(TAG, "App Main Start");
 
@@ -171,6 +179,7 @@ void app_main(void) {
     ESP_LOGE(TAG, "failed to initialize WiFi");
     return;
   }
+  wifi_register_disconnect_callback(show_config_screen);
   esp_register_shutdown_handler(&wifi_shutdown);
 
   // Wait a bit for the AP to start
@@ -190,10 +199,8 @@ void app_main(void) {
     ESP_LOGI(TAG, "WiFi connected successfully!");
   }
 
-  
   // Load up the config webp so that we don't just loop the boot screen over and over again but show the ap config info webp
-  ESP_LOGI(TAG, "Loading Config WEBP");
-  gfx_update(ASSET_CONFIG_WEBP, ASSET_CONFIG_WEBP_LEN);
+  show_config_screen();
   
   if (!wifi_is_connected()) {
     ESP_LOGW(TAG,"Pausing main task until wifi connected . . . ");

--- a/src/wifi.c
+++ b/src/wifi.c
@@ -710,7 +710,7 @@ static esp_err_t save_handler(httpd_req_t *req) {
     ESP_LOGI(TAG, "Re-enabling AP+STA to attempt new connection");
     ESP_ERROR_CHECK( esp_wifi_set_mode(WIFI_MODE_APSTA) );
     // Enable the DHCP server here, just in case we were previously in STA mode only (no DHCP)
-    esp_netif_dhcps_start(s_ap_netif)
+    esp_netif_dhcps_start(s_ap_netif);
     connect_to_ap();
 
     return ESP_OK;

--- a/src/wifi.c
+++ b/src/wifi.c
@@ -709,6 +709,8 @@ static esp_err_t save_handler(httpd_req_t *req) {
     // Connect to the new AP
     ESP_LOGI(TAG, "Re-enabling AP+STA to attempt new connection");
     ESP_ERROR_CHECK( esp_wifi_set_mode(WIFI_MODE_APSTA) );
+    // Enable the DHCP server here, just in case we were previously in STA mode only (no DHCP)
+    esp_netif_dhcps_start(s_ap_netif)
     connect_to_ap();
 
     return ESP_OK;


### PR DESCRIPTION
Hi!

Earlier today, I noticed the `TRONBYT-CONFIG` network was sticking around, even though my Tronbyt was connected to WiFi and actively fetching images. Since `TRONBYT-CONFIG` is an unsecured network, this effectively allows anyone to re-configure the Tronbyt to reconnect somewhere else, which is not ideal.

This PR changes a few things to prevent that.

**Stops the open AP once we're connected to a network**
As soon as we get an IP (in `IP_EVENT_STA_GOT_IP`), we call `esp_netif_dhcps_stop()` and switch to `WIFI_MODE_STA` so that the unsecured `TRONBYT-CONFIG` SSID disappears.

**Only fall back to an AP when we're disconnected from WiFi or fail to connect**
If the STA interface fails to reconnect after `MAX_RECONNECT_ATTEMPTS`, we switch to AP-only mode (not AP+STA) so that the device can still be re-configured - the STA interface stays down until new credentials are submitted, since there's no point in leaving it on - we're not actively connecting because at that point, we've exceeded `MAX_RECONNECT_ATTEMPTS` and have given up.

**Re-enable AP+STA on manual re-configuration via the web UI**
When the user submits new WiFi settings via the web UI, go back to `WIFI_MODE_APSTA`, then attempt to join the target network. If it succeeds, the AP drops again. In reality, we could probably just go to STA mode here, but I wanted to leave the avenue open (in the future) for immediate feedback via the web UI on whether connecting with the entered credentials was successful or not. If we switched to STA immediately here, we'd lose the option to potentially send one last response via the web UI if we were actually able to connect or not.