### PR TITLE
esp_websocket_client: bump default task stack size to 8192 bytes

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -215,6 +215,7 @@ void app_main(void) {
     // setup ws event handlers
     const esp_websocket_client_config_t ws_cfg = {
       .uri = url_to_use,
+      .task_stack  = 8192,
       .buffer_size = 10000,
       .crt_bundle_attach = esp_crt_bundle_attach,
     };


### PR DESCRIPTION
This can alleviate crashes with `wss://` addresses - 4KB might not be sufficient for the WebSocket client with TLS overhead - this change bumps the task stack size to match that of the main thread (8KB).

I was seeing crashes when trying to use `wss://` addresses - 

```
(8966) main: Using websockets with URL: wss://<snipped domain>/<snipped device ID>/ws
(8974) websocket_client: `reconnect_timeout_ms` is not set, or it is less than or equal to zero, using default time out 10000 (milliseconds)
(8988) websocket_client: `network_timeout_ms` is not set, or it is less than or equal to zero, using default time out 10000 (milliseconds)
(9001) main: WebSocket not connected. Attempting to reconnect..
(9007) websocket_client: Client was not started
(9017) websocket_client: Started
(9017) main: Reconnected to WebSocket server.
(9025) wifi:<ba-add>idx:1 (ifx:0, 9c:05:d6:f3:cb:a7), tid:6, ssn:2, winSize:64
(9464) gfx: Loaded new webp

***ERROR*** A stack overflow in task websocket_task has been detected.


Backtrace: 0x40082b58:0x3ffd6ad0 0x4008d69d:0x3ffd6af0 0x4008e84e:0x3ffd6b10 0x4008f9f3:0x3ffd6b90 0x4008e958:0x3ffd6bb0 0x4008e90a:0x00000000 |<-CORRUPTED




ELF file SHA256: 88a66a478441edb0

Rebooting...
ets Jul 29 2019 12:21:46

rst:0xc (SW_CPU_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
configsip: 0, SPIWP:0xee
clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
```

After doing some testing by bumping the `task_stack` to 8KB and adding: 

```
UBaseType_t highwater = uxTaskGetStackHighWaterMark(NULL);
ESP_LOGI(TAG, "websocket_task min free stack: %u bytes", highwater);
```
at the end of the WEBSOCKET_EVENT_DATA case, I discovered that we were using excess of 4KB - `(64965) main: websocket_task min free stack: 3956 bytes` (8192 − 3956 ≈ 4236 bytes) - roughly 200 bytes too much. 

After the bump, everything works as expected.