### PR TITLE
Add instructions to erase on-device non-volatile storage to accept secrets.json changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ If using tronbyt_manager in docker replace the ip address to the docker host's i
 Then run the following command:
 
 ```
-pio run --environment tidbyt-gen1 --target upload
+pio run \
+    --target erase &&
+    pio run \
+        --environment tidbyt-gen1 \
+        --target upload
 ```
 
 If you're flashing to a Tidbyt Gen2, just change to the above to use

--- a/README.md
+++ b/README.md
@@ -40,11 +40,7 @@ If using tronbyt_manager in docker replace the ip address to the docker host's i
 Then run the following command:
 
 ```
-pio run \
-    --target erase &&
-    pio run \
-        --environment tidbyt-gen1 \
-        --target upload
+pio run --environment tidbyt-gen1 --target erase --target upload
 ```
 
 If you're flashing to a Tidbyt Gen2, just change to the above to use


### PR DESCRIPTION
I wasted about 4 hours trying to figure this out, so I figured I'd add this to help others. Basically, it caches the settings in `secrets.json` the first time you run upload on in-device non-volatile storage, so subsequent runs will fail to upload any parameters there, for example (and in my case) the URL of the remote server.
