### PR TITLE
use strcasecmp when detecting heading names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 dependencies.lock
 _secrets.json
 sdkconfig.matrixportal-s3
+_secrets.json.injected

--- a/src/remote.c
+++ b/src/remote.c
@@ -43,7 +43,7 @@ static esp_err_t _httpCallback(esp_http_client_event_t* event) {
                event->header_value);
       
       // Check for the Content-Length header
-      if (strcmp(event->header_key, "Content-Length") == 0) {
+      if (strcasecmp(event->header_key, "Content-Length") == 0) {
         size_t content_length = (size_t)atoi(event->header_value);
         if (content_length > state->max) {
           ESP_LOGE(TAG,
@@ -57,11 +57,11 @@ static esp_err_t _httpCallback(esp_http_client_event_t* event) {
       }
 
       // Check for the specific header key
-      if (strcmp(event->header_key, "Tronbyt-Brightness") == 0) {
+      if (strcasecmp(event->header_key, "Tronbyt-Brightness") == 0) {
         state->brightness = (uint8_t)atoi(event->header_value); // API spec: 0-100
         ESP_LOGD(TAG, "Tronbyt-Brightness value: %d%%", state->brightness);
       }
-      else if (strcmp(event->header_key, "Tronbyt-Dwell-Secs") == 0) {
+      else if (strcasecmp(event->header_key, "Tronbyt-Dwell-Secs") == 0) {
         state->dwell_secs = (int)atoi(event->header_value);
         // ESP_LOGI(TAG, "Tronbyt-Dwell-Secs value: %i", dwell_secs_value);
       }


### PR DESCRIPTION
Render.com strips case from custom headers and http/2 says all headers should be lower case so just use strcasecmp when detecting content-lengh and and brightness/dwell headers from the server.