### PR TITLE
Add 8Hz Patched environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ To check the output of your running firmware, run the following:
 pio device monitor
 ```
 
-## Alternative Displays
+## 8Hz Displays
 
-There have been minor issues with certain displays showing red artifacts and slightly off color-pallettes.
+There have been minor issues with certain displays showing red artifacts and slightly off color-pallettes. This seems most likely related to manufacturing tolerances.
 
 In these cases you can use the following environments to try the display at 8Hz instead of 10Hz for the coresponding environments:
 
@@ -64,7 +64,7 @@ In these cases you can use the following environments to try the display at 8Hz 
 - `tidbyt-gen1_swap-patched`
 - `tidbyt-gen2-patched`
 
-This patches the HUB75 matrix library to use the legacy clock division calculation that the OS Tidbyt library uses before build.
+This [patches](extra_scripts/patch_i2s_divider.py) the HUB75 matrix library to use the legacy clock division calculation that the [OS Tidbyt library](https://github.com/tidbyt/ESP32-HUB75-MatrixPanel-I2S-DMA/blob/8f284afe7ba4ff369a4427121338e1673026320e/esp32_i2s_parallel_dma.c#L163) uses before build.
 
 ## Back to Normal
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ To check the output of your running firmware, run the following:
 pio device monitor
 ```
 
+## Alternative Displays
+
+There have been minor issues with certain displays showing red artifacts and slightly off color-pallettes.
+
+In these cases you can use the following environments to try the display at 8Hz instead of 10Hz for the coresponding environments:
+
+- `tidbyt-gen1-patched`
+- `tidbyt-gen1_swap-patched`
+- `tidbyt-gen2-patched`
+
+This patches the HUB75 matrix library to use the legacy clock division calculation that the OS Tidbyt library uses before build.
+
 ## Back to Normal
 
 To get your Tidbyt back to normal, you can run the following to flash the

--- a/extra_scripts/patch_i2s_divider.py
+++ b/extra_scripts/patch_i2s_divider.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""
+PlatformIO script to patch ESP32 I2S parallel DMA divider calculation
+Only runs for specific patched configurations
+"""
+
+import os
+import re
+from pathlib import Path
+
+Import("env")
+
+def patch_i2s_divider():
+    """Patch the I2S divider calculation in the ESP32 HUB75 library"""
+    
+    # Only run for patched configurations
+    current_env = env.subst("$PIOENV")
+    if not current_env.endswith("-patched"):
+        return
+    
+    print(f"Running I2S divider patch for environment: {current_env}")
+    
+    # Path to the library source file
+    lib_path = Path(env.subst("$PROJECT_LIBDEPS_DIR")) / current_env / "ESP32 HUB75 LED MATRIX PANEL DMA Display" / "src" / "platforms" / "esp32" / "esp32_i2s_parallel_dma.cpp"
+    
+    if not lib_path.exists():
+        print(f"Warning: Could not find I2S library file at {lib_path}")
+        return
+    
+    # Read the file
+    content = lib_path.read_text()
+    
+    # Pattern to match the incorrect divider line for ESP32 (non-S2), with optional comment
+    incorrect_pattern = r'unsigned int _div_num = \(freq > 8000000\) \? 2:4;.*'
+    
+    # Replacement with correct calculation
+    correct_calculation = 'unsigned int _div_num = 80000000L / freq / 2;'
+    
+    # Check if we need to patch
+    if re.search(incorrect_pattern, content):
+        print("⚙️  Patching I2S divider calculation...")
+        content = re.sub(incorrect_pattern, correct_calculation, content)
+        lib_path.write_text(content)
+        print("✅ I2S divider patch applied successfully - now using: unsigned int _div_num = 80000000L / freq / 2;")
+    elif correct_calculation in content:
+        print("✅ I2S divider already patched correctly - using: unsigned int _div_num = 80000000L / freq / 2;")
+    else:
+        print("⚠️  Warning: Could not find expected I2S divider pattern to patch")
+        print("    Expected to find: unsigned int _div_num = (freq > 8000000) ? 2:4;")
+        print("    Or already patched: unsigned int _div_num = 80000000L / freq / 2;")
+
+# Run the patch immediately when this script is loaded
+patch_i2s_divider()

--- a/extra_scripts/reset.py
+++ b/extra_scripts/reset.py
@@ -6,10 +6,13 @@ Import("env")
 PRODUCTION_VERSION = {
     "tidbyt-gen1": "v10/35833",
     "tidbyt-gen1_swap": "v10/35833",
+    "tidbyt-gen1-patched": "v10/35833",
+    "tidbyt-gen1_swap-patched": "v10/35833",
     "pixoticker": "v10/35833",
     "tronbyt-s3": "v10/35833",
     "tronbyt-s3-wide": "v10/35833",
     "tidbyt-gen2": "v11/35369",
+    "tidbyt-gen2-patched": "v11/35369",
     "matrixportal-s3": "v11/35369", # just to shut up the errors.
     "matrixportal-s3-waveshare": "v11/35369" # just to shut up the errors.
 }[env["PIOENV"]]

--- a/platformio.ini
+++ b/platformio.ini
@@ -59,6 +59,45 @@ lib_deps =
 	https://github.com/webmproject/libwebp.git#1d86819f49edc8237fa2b844543081bcb8ef8a92
 	https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA.git#aed04adfcda1838bf85c629a8c3b560919b3a327 ; commit as of 20250320
 
+[env:tidbyt-gen1-patched]
+board = tidbyt
+board_build.partitions = boards/default_8mb.csv
+board_build.cmake_extra_args = 
+    -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;"
+build_flags = 
+	-D NO_GFX
+	-D NO_FAST_FUNCTIONS
+	-D HTTP_BUFFER_SIZE_MAX=460000
+	-D HTTP_BUFFER_SIZE_DEFAULT=100000
+lib_deps = 
+	https://github.com/webmproject/libwebp.git#1d86819f49edc8237fa2b844543081bcb8ef8a92
+	https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA.git#aed04adfcda1838bf85c629a8c3b560919b3a327 ; commit as of 20250320
+extra_scripts = 
+	pre:extra_scripts/pre.py
+	post:extra_scripts/post.py
+	extra_scripts/reset.py
+	pre:extra_scripts/patch_i2s_divider.py
+
+[env:tidbyt-gen1_swap-patched]
+board = tidbyt
+board_build.partitions = boards/default_8mb.csv
+board_build.cmake_extra_args = 
+    -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;"
+build_flags = 
+	-D NO_GFX
+	-D NO_FAST_FUNCTIONS
+	-D SWAP_COLORS
+	-D HTTP_BUFFER_SIZE_MAX=460000
+	-D HTTP_BUFFER_SIZE_DEFAULT=100000
+lib_deps = 
+	https://github.com/webmproject/libwebp.git#1d86819f49edc8237fa2b844543081bcb8ef8a92
+	https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA.git#aed04adfcda1838bf85c629a8c3b560919b3a327 ; commit as of 20250320
+extra_scripts = 
+	pre:extra_scripts/pre.py
+	post:extra_scripts/post.py
+	extra_scripts/reset.py
+	pre:extra_scripts/patch_i2s_divider.py
+
 ;###################################################################################
 ;###################################################################################
 
@@ -88,6 +127,28 @@ build_flags =
 lib_deps = 
 	https://github.com/webmproject/libwebp.git#1d86819f49edc8237fa2b844543081bcb8ef8a92
 	https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA.git#aed04adfcda1838bf85c629a8c3b560919b3a327 ; commit as of 20250320
+
+[env:tidbyt-gen2-patched]
+board = gen2
+board_build.partitions = boards/default_8mb.csv
+board_build.cmake_extra_args = 
+    -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;"
+build_flags = 
+	-D NO_GFX
+	-D NO_FAST_FUNCTIONS
+	-D TIDBYT_GEN2
+	-D NO_INVERT_CLOCK_PHASE
+	-D BOOT_WEBP_TRONBYT ; not required as this is the default
+	-D HTTP_BUFFER_SIZE_MAX=460000
+	-D HTTP_BUFFER_SIZE_DEFAULT=100000
+lib_deps = 
+	https://github.com/webmproject/libwebp.git#1d86819f49edc8237fa2b844543081bcb8ef8a92
+	https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA.git#aed04adfcda1838bf85c629a8c3b560919b3a327 ; commit as of 20250320
+extra_scripts = 
+	pre:extra_scripts/pre.py
+	post:extra_scripts/post.py
+	extra_scripts/reset.py
+	pre:extra_scripts/patch_i2s_divider.py
 ;###################################################################################
 ;###################################################################################
 


### PR DESCRIPTION
This adds 3 new environments that will patch the HUB75 code before builds if it hasn't been patched to use 8Hz clock division for the matrix panels. This is what the legacy Tidbyt OS was using when they released and it seems some panels suffer manufacturing tolerance that require this.

This only affects the newly created environments. This may not be necessary if the upstream HUB75 library can add build flags but in that case we should change these environments to simply use the new build flags instead of wholesale overriding the existing environments. 