### PR TITLE
Refactor gfx_update and draw_webp to include dwell_secs parameter for…

### DIFF
--- a/src/gfx.c
+++ b/src/gfx.c
@@ -84,7 +84,6 @@ int gfx_initialize(const void *webp, size_t len) {
 
   return 0;
 }
-
 int gfx_update(void *webp, size_t len, int32_t dwell_secs) {
   if (pdTRUE != xSemaphoreTake(_state->mutex, portMAX_DELAY)) {
     ESP_LOGE(TAG, "Could not take gfx mutex");
@@ -245,11 +244,8 @@ static int draw_webp(uint8_t *buf, size_t len, int32_t dwell_secs, int32_t *isAn
     }
   }
   WebPAnimDecoderDelete(decoder);
-  if (app_dwell_secs != 0) {
-    ESP_LOGI(TAG, "Setting isAnimating to 0");
-    *isAnimating = 0;  // only set this to zero if it wasn't already set to
-                       // zero. setting it again might overwrite what the main
-                       // loop did while we were re-looping
-  }
+
+  ESP_LOGI(TAG, "Setting isAnimating to 0");
+  *isAnimating = 0;
   return 0;
 }

--- a/src/gfx.h
+++ b/src/gfx.h
@@ -5,5 +5,5 @@
 
 
 int gfx_initialize(const void* webp, size_t len);
-void gfx_update(const void* webp, size_t len, int32_t dwell_secs);
+int gfx_update(void* webp, size_t len, int32_t dwell_secs);
 void gfx_shutdown();

--- a/src/gfx.h
+++ b/src/gfx.h
@@ -5,5 +5,5 @@
 
 
 int gfx_initialize(const void* webp, size_t len);
-void gfx_update(const void* webp, size_t len);
+void gfx_update(const void* webp, size_t len, int32_t dwell_secs);
 void gfx_shutdown();

--- a/src/main.c
+++ b/src/main.c
@@ -26,8 +26,7 @@
 #define DEFAULT_URL "http://URL.NOT.SET/"
 
 static const char* TAG = "main";
-int32_t isAnimating =
-    5;  // Initialize with a valid value enough time for boot animation
+int32_t isAnimating = 1;
 int32_t app_dwell_secs = REFRESH_INTERVAL_SECONDS;
 uint8_t *webp; // main buffer downloaded webp data
 
@@ -166,7 +165,7 @@ static void websocket_event_handler(void *handler_args, esp_event_base_t base,
         // If complete, process the WebP image
         if (is_complete) {
           // Process the complete binary data as a WebP image
-          gfx_update(webp, data->payload_len);
+          gfx_update(webp, data->payload_len, app_dwell_secs);
 
           // We don't control timing during websocket so use this to notify new data and to break out of current animation.
           isAnimating = -1;
@@ -265,7 +264,7 @@ void app_main(void) {
     uint8_t *config_webp_heap_copy = (uint8_t *)malloc(ASSET_CONFIG_WEBP_LEN);
     if (config_webp_heap_copy != NULL) {
       memcpy(config_webp_heap_copy, ASSET_CONFIG_WEBP, ASSET_CONFIG_WEBP_LEN);
-      gfx_update(config_webp_heap_copy, ASSET_CONFIG_WEBP_LEN);
+      gfx_update(config_webp_heap_copy, ASSET_CONFIG_WEBP_LEN, 0);  // No dwell for config screen
       // gfx_update now owns the config_webp_heap_copy buffer.
       // main.c should not free it.
     } else {
@@ -393,21 +392,21 @@ void app_main(void) {
         // Successful remote_get
         display_set_brightness(brightness_pct);
         ESP_LOGI(TAG, BLUE "Queuing new webp (%d bytes)" RESET, len);
-        gfx_update(webp, len);
+        
+        gfx_update(webp, len, app_dwell_secs);
         // Do not free(webp) here; ownership is transferred to gfx
         webp = NULL;
         // Wait for app_dwell_secs to expire (isAnimating will be 0)
-        ESP_LOGI(TAG, BLUE "isAnimating is %d" RESET, (int)isAnimating);
-        if (isAnimating > 0)
-          ESP_LOGI(TAG, BLUE "Delay for current webp" RESET);
+        // ESP_LOGI(TAG, BLUE "isAnimating is %d" RESET, (int)isAnimating);
+        if (isAnimating > 0) ESP_LOGI(TAG, BLUE "Waiting for current webp to finish" RESET);
         while (isAnimating > 0) {
+          // ESP_LOGI(TAG, BLUE "Delay 1" RESET);
           vTaskDelay(pdMS_TO_TICKS(1));
         }
-        ESP_LOGI(TAG, BLUE "Setting isAnimating to %d" RESET,
-                (int)app_dwell_secs);
-        isAnimating = app_dwell_secs;  // use isAnimating as the container
+        // ESP_LOGI(TAG, BLUE "Setting isAnimating to 1" RESET);
+        isAnimating = 1;  // use isAnimating as the container
                                       // for app_dwell_secs
-        vTaskDelay(pdMS_TO_TICKS(1000));
+        vTaskDelay(pdMS_TO_TICKS(500));
       }
       wifi_health_check();
     }

--- a/src/main.c
+++ b/src/main.c
@@ -404,8 +404,7 @@ void app_main(void) {
           vTaskDelay(pdMS_TO_TICKS(1));
         }
         // ESP_LOGI(TAG, BLUE "Setting isAnimating to 1" RESET);
-        isAnimating = 1;  // use isAnimating as the container
-                                      // for app_dwell_secs
+        isAnimating = 1;
         vTaskDelay(pdMS_TO_TICKS(500));
       }
       wifi_health_check();

--- a/src/wifi.c
+++ b/src/wifi.c
@@ -10,6 +10,7 @@
 #include "esp_event.h"
 #include "esp_log.h"
 #include "esp_system.h"
+#include "esp_random.h"
 #include "nvs_flash.h"
 #include "nvs.h"
 #include "esp_netif.h"
@@ -272,13 +273,17 @@ int wifi_initialize(const char *ssid, const char *password) {
   strcpy((char *)ap_config.ap.ssid, DEFAULT_AP_SSID);
   // strcpy((char *)ap_config.ap.password, DEFAULT_AP_PASSWORD);
   ap_config.ap.ssid_len = strlen(DEFAULT_AP_SSID);
-  ap_config.ap.channel = 1;
+
+  // Pick a random WiFi channel (1-11 for 2.4GHz)
+  uint8_t random_channel = (esp_random() % 11) + 1;
+  ap_config.ap.channel = random_channel;
+
   ap_config.ap.max_connection = 4;
   ap_config.ap.authmode = WIFI_AUTH_OPEN;
   ap_config.ap.beacon_interval = 100;  // Default beacon interval
   // failure_retry_cnt ??
 
-      ESP_LOGI(TAG, "Setting AP SSID: %s", DEFAULT_AP_SSID);
+      ESP_LOGI(TAG, "Setting AP SSID: %s on channel %d", DEFAULT_AP_SSID, random_channel);
   ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_AP, &ap_config));
 
   // Start WiFi


### PR DESCRIPTION
… improved animation control
Basically pass in dwell_secs when calling gfx_update instead of using isAnimating for dual purpose.  This avoids weird timing issues. fixes #66 
also pick a random wifi channel for config portal fixes #67 