### PR TITLE
remember brightness accross restarts and add skip version/animation options to wifi config portal

### DIFF
--- a/main/ap.c
+++ b/main/ap.c
@@ -95,6 +95,30 @@ static const char *s_html_gen2_end =
     "</div>";
 #endif
 
+static const char *s_html_skip_version_start =
+    "<div class='form-group'>"
+    "<label>"
+    "<input type='checkbox' id='skip_display_version' "
+    "name='skip_display_version' value='1' ";
+
+static const char *s_html_skip_version_end =
+    ">"
+    " Skip Version Display (requires reboot)"
+    "</label>"
+    "</div>";
+
+static const char *s_html_skip_boot_start =
+    "<div class='form-group'>"
+    "<label>"
+    "<input type='checkbox' id='skip_boot_animation' "
+    "name='skip_boot_animation' value='1' ";
+
+static const char *s_html_skip_boot_end =
+    ">"
+    " Skip Boot Animation (requires reboot)"
+    "</label>"
+    "</div>";
+
 static const char *s_html_part4 =
     "<button type='submit'>Save and Connect</button>"
     "</form>"
@@ -404,6 +428,30 @@ static esp_err_t root_handler(httpd_req_t *req) {
       break;
 #endif
 
+    if ((ret = httpd_resp_send_chunk(req, s_html_skip_version_start,
+                                     HTTPD_RESP_USE_STRLEN)) != ESP_OK)
+      break;
+    if (nvs_get_skip_display_version()) {
+      if ((ret = httpd_resp_send_chunk(req, "checked",
+                                       HTTPD_RESP_USE_STRLEN)) != ESP_OK)
+        break;
+    }
+    if ((ret = httpd_resp_send_chunk(req, s_html_skip_version_end,
+                                     HTTPD_RESP_USE_STRLEN)) != ESP_OK)
+      break;
+
+    if ((ret = httpd_resp_send_chunk(req, s_html_skip_boot_start,
+                                     HTTPD_RESP_USE_STRLEN)) != ESP_OK)
+      break;
+    if (nvs_get_skip_boot_animation()) {
+      if ((ret = httpd_resp_send_chunk(req, "checked",
+                                       HTTPD_RESP_USE_STRLEN)) != ESP_OK)
+        break;
+    }
+    if ((ret = httpd_resp_send_chunk(req, s_html_skip_boot_end,
+                                     HTTPD_RESP_USE_STRLEN)) != ESP_OK)
+      break;
+
     // Send Part 4 (End)
     if ((ret = httpd_resp_send_chunk(req, s_html_part4,
                                      HTTPD_RESP_USE_STRLEN)) != ESP_OK)
@@ -488,8 +536,12 @@ static esp_err_t save_handler(httpd_req_t *req) {
   char image_url[400] = {0};
   char swap_val[2] = {0};
   char touch_val[4] = {0};
+  char skip_version_val[4] = {0};
+  char skip_boot_val[4] = {0};
   bool swap_colors = false;
   bool disable_touch = false;
+  bool skip_display_version = false;
+  bool skip_boot_animation = false;
 
   // Use httpd_query_key_value to parse form data
   if (httpd_query_key_value(buf, "ssid", ssid, sizeof(ssid)) != ESP_OK) {
@@ -516,20 +568,35 @@ static esp_err_t save_handler(httpd_req_t *req) {
     disable_touch = (strcmp(touch_val, "1") == 0);
   }
 
+  if (httpd_query_key_value(buf, "skip_display_version", skip_version_val,
+                            sizeof(skip_version_val)) == ESP_OK) {
+    skip_display_version = (strcmp(skip_version_val, "1") == 0);
+  }
+
+  if (httpd_query_key_value(buf, "skip_boot_animation", skip_boot_val,
+                            sizeof(skip_boot_val)) == ESP_OK) {
+    skip_boot_animation = (strcmp(skip_boot_val, "1") == 0);
+  }
+
   url_decode(ssid);
   url_decode(password);
   url_decode(image_url);
 
   ESP_LOGI(TAG,
-           "Received SSID: %s, Image URL: %s, Swap Colors: %s, Disable Touch: %s",
+           "Received SSID: %s, Image URL: %s, Swap Colors: %s, Disable Touch: "
+           "%s, Skip Version: %s, Skip Boot: %s",
            ssid, image_url, swap_colors ? "true" : "false",
-           disable_touch ? "true" : "false");
+           disable_touch ? "true" : "false",
+           skip_display_version ? "true" : "false",
+           skip_boot_animation ? "true" : "false");
 
   nvs_set_ssid(ssid);
   nvs_set_password(password);
   nvs_set_image_url(strlen(image_url) < 6 ? NULL : image_url);
   nvs_set_swap_colors(swap_colors);
   nvs_set_disable_touch(disable_touch);
+  nvs_set_skip_display_version(skip_display_version);
+  nvs_set_skip_boot_animation(skip_boot_animation);
   nvs_save_settings();
 
   free(buf);

--- a/main/display.cpp
+++ b/main/display.cpp
@@ -166,6 +166,21 @@ static MatrixPanel_I2S_DMA *_matrix;
 static uint8_t _brightness = DISPLAY_DEFAULT_BRIGHTNESS;
 static const char *TAG = "display";
 
+// Per-board ceiling for the 0-100% -> setBrightness8() (0-255) mapping.
+// Genuine Tidbyt hardware (Gen1/Gen2) defines this as 100 in its board block
+// above, matching the stock HDK convention where the brightness percentage
+// feeds setBrightness8() 1:1 (max ~39% panel PWM duty). Third-party panels with
+// no Tidbyt reference fall back to the legacy 230 (~90% duty) and can be tuned
+// empirically per board.
+#ifndef BRIGHTNESS_8BIT_MAX
+#define BRIGHTNESS_8BIT_MAX 230
+#endif
+
+static inline uint8_t brightness_percent_to_8bit(uint8_t pct) {
+  if (pct > 100) pct = 100;
+  return (uint8_t)(((uint32_t)pct * BRIGHTNESS_8BIT_MAX + 50) / 100);
+}
+
 int display_initialize(void) {
   // Get swap_colors setting
   bool swap_colors = nvs_get_swap_colors();
@@ -221,24 +236,15 @@ int display_initialize(void) {
     _matrix = NULL;
     return 1;
   }
-  display_set_brightness(DISPLAY_DEFAULT_BRIGHTNESS);
+
+  // Apply stored brightness immediately so reboots (especially at night with
+  // brightness 0) don't flash the boot animation at full brightness.
+  uint8_t brightness_pct = nvs_get_brightness();
+  _matrix->setBrightness8(brightness_percent_to_8bit(brightness_pct));
+  _brightness = brightness_pct;
+  ESP_LOGI(TAG, "Restored brightness to %d%%", brightness_pct);
 
   return 0;
-}
-
-// Per-board ceiling for the 0-100% -> setBrightness8() (0-255) mapping.
-// Genuine Tidbyt hardware (Gen1/Gen2) defines this as 100 in its board block
-// above, matching the stock HDK convention where the brightness percentage
-// feeds setBrightness8() 1:1 (max ~39% panel PWM duty). Third-party panels with
-// no Tidbyt reference fall back to the legacy 230 (~90% duty) and can be tuned
-// empirically per board.
-#ifndef BRIGHTNESS_8BIT_MAX
-#define BRIGHTNESS_8BIT_MAX 230
-#endif
-
-static inline uint8_t brightness_percent_to_8bit(uint8_t pct) {
-  if (pct > 100) pct = 100;
-  return (uint8_t)(((uint32_t)pct * BRIGHTNESS_8BIT_MAX + 50) / 100);
 }
 
 void display_set_brightness(uint8_t brightness_pct) {
@@ -250,6 +256,8 @@ void display_set_brightness(uint8_t brightness_pct) {
     _matrix->setBrightness8(brightness_8bit);
     _matrix->clearScreen();
     _brightness = brightness_pct;
+    nvs_set_brightness(brightness_pct);
+    nvs_persist_brightness();
   }
 }
 

--- a/main/display.cpp
+++ b/main/display.cpp
@@ -177,7 +177,6 @@ static const char *TAG = "display";
 #endif
 
 static inline uint8_t brightness_percent_to_8bit(uint8_t pct) {
-  if (pct > 100) pct = 100;
   return (uint8_t)(((uint32_t)pct * BRIGHTNESS_8BIT_MAX + 50) / 100);
 }
 
@@ -248,6 +247,11 @@ int display_initialize(void) {
 }
 
 void display_set_brightness(uint8_t brightness_pct) {
+  if (brightness_pct > DISPLAY_MAX_BRIGHTNESS) {
+    ESP_LOGW(TAG, "Ignoring invalid brightness %u (valid range %d-%d)",
+             brightness_pct, DISPLAY_MIN_BRIGHTNESS, DISPLAY_MAX_BRIGHTNESS);
+    return;
+  }
   if (brightness_pct != _brightness) {
     uint8_t brightness_8bit = brightness_percent_to_8bit(brightness_pct);
 
@@ -256,8 +260,12 @@ void display_set_brightness(uint8_t brightness_pct) {
     _matrix->setBrightness8(brightness_8bit);
     _matrix->clearScreen();
     _brightness = brightness_pct;
-    nvs_set_brightness(brightness_pct);
-    nvs_persist_brightness();
+    esp_err_t err = nvs_set_brightness(brightness_pct);
+    if (err != ESP_OK) {
+      ESP_LOGW(TAG, "Failed to store brightness: %s", esp_err_to_name(err));
+    } else if ((err = nvs_persist_brightness()) != ESP_OK) {
+      ESP_LOGW(TAG, "Failed to persist brightness: %s", esp_err_to_name(err));
+    }
   }
 }
 

--- a/main/gfx.c
+++ b/main/gfx.c
@@ -405,12 +405,12 @@ static void gfx_loop(void *args) {
       continue;
     }
 
-    // static int stack_check_counter = 0;
-    // if (++stack_check_counter >= 100) {
-      // stack_check_counter = 0;
-      UBaseType_t stack_free = uxTaskGetStackHighWaterMark(NULL);
+    static UBaseType_t last_stack_free = 0;
+    UBaseType_t stack_free = uxTaskGetStackHighWaterMark(NULL);
+    if (stack_free != last_stack_free) {
       ESP_LOGI(TAG, "Stack remaining: %u bytes", stack_free);
-    // }
+      last_stack_free = stack_free;
+    }
 
     if (webp && len > 0) {
       if (draw_webp(webp, len, dwell_secs, &isAnimating)) {

--- a/main/main.c
+++ b/main/main.c
@@ -515,6 +515,14 @@ void app_main(void) {
   // Initialize NVS settings
   ESP_ERROR_CHECK(nvs_settings_init());
 
+#ifdef CONFIG_BOARD_TIDBYT_GEN2
+  saved_brightness = nvs_get_brightness();
+  if (saved_brightness == 0) {
+    saved_brightness = 30;
+  }
+  display_power_on = nvs_get_brightness() > 0;
+#endif
+
   // Setup WiFi.
   ESP_LOGI(TAG, "Initializing WiFi manager...");
   // Pass empty strings to force AP mode
@@ -832,10 +840,10 @@ void app_main(void) {
   } else {
     // normal http
     ESP_LOGW(TAG, "HTTP Loop Start with URL: %s", image_url);
+    uint8_t brightness_pct = nvs_get_brightness();
     for (;;) {
       uint8_t* webp;
       size_t len;
-      static uint8_t brightness_pct = DISPLAY_DEFAULT_BRIGHTNESS;
       int status_code = 0;
       ESP_LOGI(TAG, "Fetching from URL: %s", image_url);
       char* ota_url = NULL;

--- a/main/nvs_settings.c
+++ b/main/nvs_settings.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "display.h"
 #include "esp_log.h"
 #include "esp_wifi_types.h"
 #include "nvs.h"
@@ -28,6 +29,7 @@
 #define NVS_KEY_PREFER_IPV6 "prefer_ipv6"
 #define NVS_KEY_DISABLE_TOUCH "dis_touch"
 #define NVS_KEY_API_KEY "api_key"
+#define NVS_KEY_BRIGHTNESS "brightness"
 
 // Internal storage
 static char s_wifi_ssid[MAX_SSID_LEN + 1] = {0};
@@ -44,6 +46,7 @@ static bool s_ap_mode = true;
 static bool s_prefer_ipv6 = false;
 static bool s_disable_touch = false;
 static char s_api_key[MAX_API_KEY_LEN + 1] = {0};
+static uint8_t s_brightness = DISPLAY_DEFAULT_BRIGHTNESS;
 
 // Hardcoded defaults (from secrets.json via generated secrets_gen.h)
 #include "secrets_gen.h"
@@ -169,6 +172,10 @@ esp_err_t nvs_settings_init(void) {
       s_disable_touch = (val_u8 != 0);
     }
 
+    if (nvs_get_u8(nvs_handle, NVS_KEY_BRIGHTNESS, &val_u8) == ESP_OK) {
+      s_brightness = val_u8;
+    }
+
     required_size = sizeof(s_api_key);
     if (nvs_get_str(nvs_handle, NVS_KEY_API_KEY, s_api_key,
                     &required_size) != ESP_OK) {
@@ -269,6 +276,8 @@ bool nvs_get_ap_mode(void) { return s_ap_mode; }
 bool nvs_get_prefer_ipv6(void) { return s_prefer_ipv6; }
 
 bool nvs_get_disable_touch(void) { return s_disable_touch; }
+
+uint8_t nvs_get_brightness(void) { return s_brightness; }
 
 esp_err_t nvs_get_api_key(char *api_key, size_t max_len) {
   if (!api_key) return ESP_ERR_INVALID_ARG;
@@ -405,6 +414,27 @@ esp_err_t nvs_set_disable_touch(bool disable_touch) {
   return ESP_OK;
 }
 
+esp_err_t nvs_set_brightness(uint8_t brightness) {
+  if (brightness > DISPLAY_MAX_BRIGHTNESS) {
+    return ESP_ERR_INVALID_ARG;
+  }
+  s_brightness = brightness;
+  return ESP_OK;
+}
+
+esp_err_t nvs_persist_brightness(void) {
+  nvs_handle_t nvs_handle;
+  esp_err_t err = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle);
+  if (err != ESP_OK) return err;
+
+  err = nvs_set_u8(nvs_handle, NVS_KEY_BRIGHTNESS, s_brightness);
+  if (err == ESP_OK) {
+    err = nvs_commit(nvs_handle);
+  }
+  nvs_close(nvs_handle);
+  return err;
+}
+
 esp_err_t nvs_save_settings(void) {
   nvs_handle_t nvs_handle;
   esp_err_t err;
@@ -427,6 +457,7 @@ esp_err_t nvs_save_settings(void) {
   nvs_set_u8(nvs_handle, NVS_KEY_AP_MODE, s_ap_mode ? 1 : 0);
   nvs_set_u8(nvs_handle, NVS_KEY_PREFER_IPV6, s_prefer_ipv6 ? 1 : 0);
   nvs_set_u8(nvs_handle, NVS_KEY_DISABLE_TOUCH, s_disable_touch ? 1 : 0);
+  nvs_set_u8(nvs_handle, NVS_KEY_BRIGHTNESS, s_brightness);
 
   err = nvs_commit(nvs_handle);
   nvs_close(nvs_handle);

--- a/main/nvs_settings.h
+++ b/main/nvs_settings.h
@@ -38,6 +38,7 @@ bool nvs_get_skip_boot_animation(void);
 bool nvs_get_ap_mode(void);
 bool nvs_get_prefer_ipv6(void);
 bool nvs_get_disable_touch(void);
+uint8_t nvs_get_brightness(void);
 
 // Setters
 esp_err_t nvs_set_ssid(const char *ssid);
@@ -54,9 +55,11 @@ esp_err_t nvs_set_skip_boot_animation(bool skip);
 esp_err_t nvs_set_ap_mode(bool ap_mode);
 esp_err_t nvs_set_prefer_ipv6(bool prefer_ipv6);
 esp_err_t nvs_set_disable_touch(bool disable_touch);
+esp_err_t nvs_set_brightness(uint8_t brightness);
 
 // Save all modified settings to NVS
 esp_err_t nvs_save_settings(void);
+esp_err_t nvs_persist_brightness(void);
 
 #ifdef __cplusplus
 }

--- a/main/remote.c
+++ b/main/remote.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "display.h"
 #include "gfx.h"
 #include "nvs_settings.h"
 #include "sdkconfig.h"
@@ -21,7 +22,7 @@ struct remote_state {
   size_t len;
   size_t size;
   size_t max;
-  uint8_t brightness;
+  int16_t brightness;
   int32_t dwell_secs;
   char* ota_url;
   char* image_url;
@@ -82,9 +83,14 @@ static esp_err_t _httpCallback(esp_http_client_event_t* event) {
 
       // Check for the specific header key
       if (strcasecmp(event->header_key, "Tronbyt-Brightness") == 0) {
-        state->brightness =
-            (uint8_t)atoi(event->header_value);  // API spec: 0-100
-        ESP_LOGD(TAG, "Tronbyt-Brightness value: %d%%", state->brightness);
+        int value = atoi(event->header_value);
+        if (value >= DISPLAY_MIN_BRIGHTNESS && value <= DISPLAY_MAX_BRIGHTNESS) {
+          state->brightness = (int16_t)value;
+          ESP_LOGD(TAG, "Tronbyt-Brightness value: %d%%", value);
+        } else {
+          ESP_LOGW(TAG, "Ignoring invalid Tronbyt-Brightness: %s",
+                   event->header_value);
+        }
       } else if (strcasecmp(event->header_key, "Tronbyt-Dwell-Secs") == 0) {
         state->dwell_secs = (int)atoi(event->header_value);
         // ESP_LOGI(TAG, "Tronbyt-Dwell-Secs value: %i", dwell_secs_value);
@@ -298,7 +304,9 @@ int remote_get(const char* url, uint8_t** buf, size_t* len,
   // Write back the results.
   *buf = state.buf;
   *len = state.len;
-  *brightness_pct = state.brightness;  // Assumes API provides 0–100 as spec'd
+  if (state.brightness >= 0) {
+    *brightness_pct = (uint8_t)state.brightness;
+  }
   if (state.dwell_secs > -1 && state.dwell_secs < 300)
     *dwell_secs = state.dwell_secs;  // 5 minute max ?
   *ota_url = state.ota_url;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added settings to skip the version display and boot animation.
  * Added persistent display brightness settings that are restored after restart.
  * Brightness is now scaled appropriately for different board types.
  * Added validation for brightness values received through remote controls.

* **Bug Fixes**
  * Improved startup behavior by preserving brightness and display power state.
  * Prevented brightness from resetting during HTTP mode operation.
  * Reduced repetitive diagnostic logging during graphics processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->