### PR TITLE
fix(ws): shrink WebSocket buffer_size to preserve internal RAM

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -717,7 +717,14 @@ void app_main(void) {
     esp_websocket_client_config_t ws_cfg = {
         .uri = image_url,
         .task_stack = 8192,
-        .buffer_size = 8192,
+        // Must stay larger than the biggest WebSocket text frame the server
+        // sends (JSON config updates are dropped when fragmented across reads);
+        // binary WebP frames are reassembled into PSRAM independently of this.
+        // The rx+tx buffers are malloc'd before the client task is created and,
+        // being under 16 KiB, land in internal RAM - keep them small to
+        // preserve internal RAM for task creation on memory-constrained boards
+        // (e.g. Tronbyt S3 Wide).
+        .buffer_size = 4096,
         .crt_bundle_attach = esp_crt_bundle_attach,
         .reconnect_timeout_ms = 10000,
         .network_timeout_ms = 10000,


### PR DESCRIPTION
The WebSocket client mallocs rx_buffer and tx_buffer before its task is created. Because allocations under 16 KiB land in internal SRAM (CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL), these two buffers consumed 16 KiB of internal RAM ahead of xTaskCreate(). On memory-constrained boards such as the Tronbyt S3 Wide (~34 KiB free internal RAM after the HUB75 DMA row buffers), the subsequent 8 KiB task stack allocation failed and the device looped forever on 'Error create websocket task' / 'Failed to restart WebSocket client: ESP_FAIL'.

This surfaced as a regression with the release toolchain bump from ESP-IDF v5.5.4-1169-gbb2188bfb8 (firmware 1.6.5) to v5.5.5-108-gac63a9275a5 (firmware 1.6.6+, the CI pulls the moving espressif/idf:release-v5.5 tag): on the S3 Wide, 1.6.5 connected while 1.6.6 failed with identical server, certificate, and WiFi. The same firmwares work on the regular Tronbyt S3 (~119 KiB free internal RAM), so the updated IDF's marginally larger WiFi/TLS footprint pushed the already-marginal task allocation past its limit rather than causing a functional break. Reducing our own allocations addresses the root cause on any toolchain instead of pinning the old one.

buffer_size stays well above the floor imposed by unfragmented WebSocket text frames: JSON config updates must arrive in a single read chunk or the event handler drops them (~1 KiB worst case), so 4 KiB keeps a ~4x margin. Binary WebP frames are reassembled into PSRAM independently of this size; larger frames are simply received in smaller chunks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when receiving WebSocket configuration updates by preventing fragmented JSON messages from being dropped.
  * Reduced communication buffer usage to help preserve available memory on constrained devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->